### PR TITLE
feat: restructures std lib and adds ScriptExt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ forge install Moonsong-Labs/forge-zksync-std
 
 ## Usage
 
+Test:
+
 ```solidity
 import {Test, console2 as console} from "forge-std/Test.sol";
 import {TestExt} from "forge-zksync-std/TestExt.sol";
@@ -23,6 +25,25 @@ contract FooTest is Test, TestExt {
 
         vmExt.zkVmSkip();               // additional foundry-zksync cheatcodes
         new Contract2();
+    }
+}
+```
+
+Script:
+
+```solidity
+import {Test, console2 as console} from "forge-std/Test.sol";
+import {ScriptExt} from "forge-zksync-std/ScriptExt.sol";
+
+contract FooScript is Script, ScriptExt {
+    function deployTwoUserMultisig() public {
+        Factory factory = new Factory(multisigBytecodeHash);
+
+        // Mark the bytecode as a factory dependency
+        vmExt.zkUseFactoryDep("TwoUserMultisig");
+
+        // Deploy the account using the factory
+        factory.deployAccount(multisigBytecodeHash);
     }
 }
 ```

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,3 +4,13 @@ out = "out"
 libs = ["lib"]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
+[fmt]
+# These are all the `forge fmt` defaults.
+line_length = 120
+tab_width = 4
+bracket_spacing = false
+int_types = 'long'
+multiline_func_header = 'attributes_first'
+quote_style = 'double'
+number_underscore = 'preserve'
+single_line_statement_blocks = 'preserve'

--- a/src/BaseExt.sol
+++ b/src/BaseExt.sol
@@ -35,7 +35,7 @@ abstract contract CommonBaseExt {
     address internal constant GAS_BOUND_CALLER = 0xc706EC7dfA5D4Dc87f29f859094165E8290530f5;
     address internal constant P256_VERIFY = 0x0000000000000000000000000000000000000100;
     // Used when deploying with create2, https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/Create2Factory.sol.
-    address internal constant CREATE2_FACTORY = 0x0000000000000000000000000000000000010000;
+    address internal constant ZKSYNC_CREATE2_FACTORY = 0x0000000000000000000000000000000000010000;
 
     VmExt internal constant vmExt = VmExt(VM_EXT_ADDRESS);
 }

--- a/src/BaseExt.sol
+++ b/src/BaseExt.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.6.2 <0.9.0;
+
+import {VmExt} from "./VmExt.sol";
+
+abstract contract CommonBaseExt {
+    // Cheat code address, 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D.
+    address internal constant VM_EXT_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));
+
+    // System contract addresses
+    address internal constant BOOTLOADER = 0x0000000000000000000000000000000000008001;
+    address internal constant ACCOUNT_CODE_STORAGE = 0x0000000000000000000000000000000000008002;
+    address internal constant NONCE_HOLDER = 0x0000000000000000000000000000000000008003;
+    address internal constant KNOWN_CODES_STORAGE = 0x0000000000000000000000000000000000008004;
+    address internal constant IMMUTABLE_SIMULATOR = 0x0000000000000000000000000000000000008005;
+    address internal constant CONTRACT_DEPLOYER = 0x0000000000000000000000000000000000008006;
+    address internal constant FORCE_L2_DEPLOYER = 0x0000000000000000000000000000000000008007;
+    address internal constant L1_MESSENGER = 0x0000000000000000000000000000000000008008;
+    address internal constant MSG_VALUE_SIMULATOR = 0x0000000000000000000000000000000000008009;
+    address internal constant L2_BASE_TOKEN = 0x000000000000000000000000000000000000800A;
+    address internal constant SYSTEM_CONTEXT = 0x000000000000000000000000000000000000800B;
+    address internal constant BOOTLOADER_UTILITIES = 0x000000000000000000000000000000000000800c;
+    address internal constant EVENT_WRITER = 0x000000000000000000000000000000000000800d;
+    address internal constant COMPRESSOR = 0x000000000000000000000000000000000000800E;
+    address internal constant COMPLEX_UPGRADER = 0x000000000000000000000000000000000000800f;
+    address internal constant KECCAK = 0x0000000000000000000000000000000000008010;
+    address internal constant PUBDATA_CHUNK_PUBLISHER = 0x0000000000000000000000000000000000008011;
+    address internal constant CODE_ORACLE = 0x0000000000000000000000000000000000008012;
+    address internal constant CONSOLE_LOG = 0x000000000000000000636F6e736F6c652e6c6f67;
+    address internal constant SHA256 = 0x0000000000000000000000000000000000000002;
+    address internal constant ECRECOVER = 0x0000000000000000000000000000000000000001;
+    address internal constant ECADD = 0x0000000000000000000000000000000000000006;
+    address internal constant ECMUL = 0x0000000000000000000000000000000000000007;
+    address internal constant EC_PAIRING = 0x0000000000000000000000000000000000000008;
+    address internal constant GAS_BOUND_CALLER = 0xc706EC7dfA5D4Dc87f29f859094165E8290530f5;
+    address internal constant P256_VERIFY = 0x0000000000000000000000000000000000000100;
+    // Used when deploying with create2, https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/Create2Factory.sol.
+    address internal constant CREATE2_FACTORY = 0x0000000000000000000000000000000000010000;
+
+    VmExt internal constant vmExt = VmExt(VM_EXT_ADDRESS);
+}
+
+abstract contract TestBaseExt is CommonBaseExt {}
+
+abstract contract ScriptBaseExt is CommonBaseExt {}

--- a/src/ScriptExt.sol
+++ b/src/ScriptExt.sol
@@ -11,6 +11,6 @@ import {ScriptBaseExt} from "./BaseExt.sol";
 
 // ⭐️ SCRIPT
 abstract contract ScriptExt is ScriptBaseExt {
-    // Note: IS_SCRIPT() must return true.
-    bool public IS_SCRIPT = true;
+    // Note: IS_SCRIPT_EXT() must return true.
+    bool public IS_SCRIPT_EXT = true;
 }

--- a/src/ScriptExt.sol
+++ b/src/ScriptExt.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.6.2 <0.9.0;
+
+// 💬 ABOUT
+// Forge Std's default Script.
+
+// 🧩 MODULES
+
+// 📦 BOILERPLATE
+import {ScriptBaseExt} from "./BaseExt.sol";
+
+// ⭐️ SCRIPT
+abstract contract Script is ScriptBaseExt {
+    // Note: IS_SCRIPT() must return true.
+    bool public IS_SCRIPT = true;
+}

--- a/src/ScriptExt.sol
+++ b/src/ScriptExt.sol
@@ -10,7 +10,7 @@ pragma solidity >=0.6.2 <0.9.0;
 import {ScriptBaseExt} from "./BaseExt.sol";
 
 // ⭐️ SCRIPT
-abstract contract Script is ScriptBaseExt {
+abstract contract ScriptExt is ScriptBaseExt {
     // Note: IS_SCRIPT() must return true.
     bool public IS_SCRIPT = true;
 }

--- a/src/TestExt.sol
+++ b/src/TestExt.sol
@@ -1,36 +1,10 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.6.2 <0.9.0;
 
-interface VmExt {
-    /// Registers bytecodes for ZK-VM for transact/call and create instructions.
-    function zkRegisterContract(
-        string calldata name,
-        bytes32 evmBytecodeHash,
-        bytes calldata evmDeployedBytecode,
-        bytes calldata evmBytecode,
-        bytes32 zkBytecodeHash,
-        bytes calldata zkDeployedBytecode
-    ) external pure;
+import {TestBaseExt} from "./BaseExt.sol";
 
-    /// Enables/Disables use ZK-VM usage for transact/call and create instructions.
-    function zkVm(bool enable) external pure;
-
-    /// When running in zkEVM context, skips the next CREATE or CALL, executing it on the EVM instead.
-    /// All `CREATE`s executed within this skip, will automatically have `CALL`s to their target addresses
-    /// executed in the EVM, and need not be marked with this cheatcode at every usage location.
-    function zkVmSkip() external pure;
-
-    /// Use a paymaster for the next ZK-VM call.
-    function zkUsePaymaster(address paymaster, bytes calldata input) external;
-
-    /// Mark a contract as a factory dependency.
-    function zkUseFactoryDep(string calldata contractName) external;
-}
-
-abstract contract TestExt {
-    // Cheat code address, 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D.
-    address internal constant VM_EXT_ADDRESS =
-        address(uint160(uint256(keccak256("hevm cheat code"))));
-
-    VmExt internal constant vmExt = VmExt(VM_EXT_ADDRESS);
+// ⭐️ TEST
+abstract contract TestExt is TestBaseExt {
+    // Note: IS_TEST() must return true.
+    bool public IS_TEST = true;
 }

--- a/src/TestExt.sol
+++ b/src/TestExt.sol
@@ -5,6 +5,6 @@ import {TestBaseExt} from "./BaseExt.sol";
 
 // ⭐️ TEST
 abstract contract TestExt is TestBaseExt {
-    // Note: IS_TEST() must return true.
-    bool public IS_TEST = true;
+    // Note: IS_TEST_EXT() must return true.
+    bool public IS_TEST_EXT = true;
 }

--- a/src/VmExt.sol
+++ b/src/VmExt.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.6.2 <0.9.0;
+
+interface VmExt {
+    /// Registers bytecodes for ZK-VM for transact/call and create instructions.
+    function zkRegisterContract(
+        string calldata name,
+        bytes32 evmBytecodeHash,
+        bytes calldata evmDeployedBytecode,
+        bytes calldata evmBytecode,
+        bytes32 zkBytecodeHash,
+        bytes calldata zkDeployedBytecode
+    ) external pure;
+
+    /// Enables/Disables use ZK-VM usage for transact/call and create instructions.
+    function zkVm(bool enable) external pure;
+
+    /// When running in zkEVM context, skips the next CREATE or CALL, executing it on the EVM instead.
+    /// All `CREATE`s executed within this skip, will automatically have `CALL`s to their target addresses
+    /// executed in the EVM, and need not be marked with this cheatcode at every usage location.
+    function zkVmSkip() external pure;
+
+    /// Use a paymaster for the next ZK-VM call.
+    function zkUsePaymaster(address paymaster, bytes calldata input) external;
+
+    /// Mark a contract as a factory dependency.
+    function zkUseFactoryDep(string calldata contractName) external;
+}


### PR DESCRIPTION
### Description 

Allows for more conventional usage for Scripts :

```
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import {Script, console} from "forge-std/Script.sol";
import {ScriptExt} from "lib/forge-zksync-std/src/ScriptExt.sol";
import {Counter} from "../src/Counter.sol";
import {GaslessPaymaster} from "../src/GaslessPaymaster.sol";

contract CounterScript is Script, ScriptExt {
    Counter public counter;
    GaslessPaymaster public paymaster;

    function setUp() public {}

    function run() public {
        
        vm.startBroadcast();
        
        GaslessPaymaster paymaster = new GaslessPaymaster();
        address(paymaster).call{value: 0.05 ether}("");

        bytes memory paymaster_encoded_input = abi.encodeWithSelector(
            bytes4(keccak256("general(bytes)")),
            bytes("0x")
        );
        vmExt.zkUsePaymaster(
            address(paymaster),
            paymaster_encoded_input
        );
        
        counter = new Counter();

        vm.stopBroadcast();
    }
}
```
